### PR TITLE
chore: Pin ECS module to sha while module is undergoing changes

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -7,8 +7,6 @@ on:
 
 env:
   TERRAFORM_DOCS_VERSION: v0.16.0
-  TFSEC_VERSION: v1.28.1
-  TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform.d/plugin-cache
   TFLINT_VERSION: v0.45.0
 
 jobs:
@@ -33,9 +31,6 @@ jobs:
       matrix:
         directory: ${{ fromJson(needs.collectInputs.outputs.directories) }}
     steps:
-      - name: Remove default Terraform
-        run: rm -rf $(which terraform)
-
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -48,18 +43,6 @@ jobs:
           filters: |
             src:
               - '${{ matrix.directory }}/*.tf'
-
-      - name: Config Terraform plugin cache
-        if: steps.changes.outputs.src == 'true'
-        run: mkdir --parents ${{ env.TERRAFORM_DOCS_VERSION }}
-
-      - name: Cache Terraform
-        uses: actions/cache@v3
-        if: steps.changes.outputs.src == 'true'
-        with:
-          path: ${{ env.TERRAFORM_DOCS_VERSION }}
-          key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
-          restore-keys: ${{ runner.os }}-terraform-
 
       - name: Terraform min/max versions
         uses: clowdhaus/terraform-min-max@v1.2.5
@@ -91,9 +74,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: collectInputs
     steps:
-      - name: Remove default Terraform
-        run: rm -rf $(which terraform)
-
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -103,22 +83,6 @@ jobs:
           filters: |
             src:
               - '**/*.tf'
-
-      - name: Config Terraform plugin cache
-        if: steps.changes.outputs.src == 'true'
-        run: mkdir --parents ${{ env.TERRAFORM_DOCS_VERSION }}
-
-      - name: Cache Terraform
-        uses: actions/cache@v3
-        if: steps.changes.outputs.src == 'true'
-        with:
-          path: ${{ env.TF_PLUGIN_CACHE_DIR }}
-          key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
-          restore-keys: ${{ runner.os }}-terraform-
-
-      - name: Install tfsec
-        if: steps.changes.outputs.src == 'true'
-        run: curl -sSLo ./tfsec https://github.com/aquasecurity/tfsec/releases/download/${{ env.TFSEC_VERSION }}/tfsec-$(uname)-amd64 && chmod +x tfsec && sudo mv tfsec /usr/bin/
 
       - name: Terraform min/max versions
         id: minMax

--- a/examples/backend-service/main.tf
+++ b/examples/backend-service/main.tf
@@ -40,7 +40,7 @@ resource "aws_service_discovery_service" "this" {
 }
 
 module "ecs_service_definition" {
-  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service"
+  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d808763ccac504eb7ddda7ceef2fc6a1ac"
 
   deployment_controller = "ECS"
 

--- a/examples/backend-service/main.tf
+++ b/examples/backend-service/main.tf
@@ -40,7 +40,7 @@ resource "aws_service_discovery_service" "this" {
 }
 
 module "ecs_service_definition" {
-  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d808763ccac504eb7ddda7ceef2fc6a1ac"
+  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d"
 
   deployment_controller = "ECS"
 

--- a/examples/backstage/main.tf
+++ b/examples/backstage/main.tf
@@ -141,7 +141,7 @@ resource "aws_service_discovery_service" "this" {
 }
 
 module "ecs_service_definition" {
-  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service"
+  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d808763ccac504eb7ddda7ceef2fc6a1ac"
 
   name          = local.name
   desired_count = 3

--- a/examples/backstage/main.tf
+++ b/examples/backstage/main.tf
@@ -141,7 +141,7 @@ resource "aws_service_discovery_service" "this" {
 }
 
 module "ecs_service_definition" {
-  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d808763ccac504eb7ddda7ceef2fc6a1ac"
+  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d"
 
   name          = local.name
   desired_count = 3

--- a/examples/core-infra/README.md
+++ b/examples/core-infra/README.md
@@ -63,7 +63,7 @@ terraform destroy
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ecs"></a> [ecs](#module\_ecs) | github.com/clowdhaus/terraform-aws-ecs | n/a |
+| <a name="module_ecs"></a> [ecs](#module\_ecs) | github.com/clowdhaus/terraform-aws-ecs | 73acc1d808763ccac504eb7ddda7ceef2fc6a1ac |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
 
 ## Resources

--- a/examples/core-infra/README.md
+++ b/examples/core-infra/README.md
@@ -63,7 +63,7 @@ terraform destroy
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ecs"></a> [ecs](#module\_ecs) | github.com/clowdhaus/terraform-aws-ecs | 73acc1d808763ccac504eb7ddda7ceef2fc6a1ac |
+| <a name="module_ecs"></a> [ecs](#module\_ecs) | github.com/clowdhaus/terraform-aws-ecs | 73acc1d |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
 
 ## Resources

--- a/examples/core-infra/main.tf
+++ b/examples/core-infra/main.tf
@@ -23,7 +23,7 @@ locals {
 ################################################################################
 
 module "ecs" {
-  source = "github.com/clowdhaus/terraform-aws-ecs?ref=73acc1d808763ccac504eb7ddda7ceef2fc6a1ac"
+  source = "github.com/clowdhaus/terraform-aws-ecs?ref=73acc1d"
   # version = "~> 4.0"
 
   cluster_name = local.name

--- a/examples/core-infra/main.tf
+++ b/examples/core-infra/main.tf
@@ -23,7 +23,7 @@ locals {
 ################################################################################
 
 module "ecs" {
-  source = "github.com/clowdhaus/terraform-aws-ecs"
+  source = "github.com/clowdhaus/terraform-aws-ecs?ref=73acc1d808763ccac504eb7ddda7ceef2fc6a1ac"
   # version = "~> 4.0"
 
   cluster_name = local.name

--- a/examples/graviton/main.tf
+++ b/examples/graviton/main.tf
@@ -180,7 +180,7 @@ resource "aws_service_discovery_service" "arm64" {
 }
 
 module "ecs_service_definition_amd64" {
-  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service"
+  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d808763ccac504eb7ddda7ceef2fc6a1ac"
 
   name          = local.name
   desired_count = 3
@@ -238,7 +238,7 @@ module "ecs_service_definition_amd64" {
 }
 
 module "ecs_service_definition_arm64" {
-  source        = "github.com/clowdhaus/terraform-aws-ecs//modules/service"
+  source        = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d808763ccac504eb7ddda7ceef2fc6a1ac"
   name          = "${local.name}-arm64"
   desired_count = 3
   cluster       = data.aws_ecs_cluster.core_infra.cluster_name

--- a/examples/graviton/main.tf
+++ b/examples/graviton/main.tf
@@ -180,7 +180,7 @@ resource "aws_service_discovery_service" "arm64" {
 }
 
 module "ecs_service_definition_amd64" {
-  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d808763ccac504eb7ddda7ceef2fc6a1ac"
+  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d"
 
   name          = local.name
   desired_count = 3
@@ -238,7 +238,7 @@ module "ecs_service_definition_amd64" {
 }
 
 module "ecs_service_definition_arm64" {
-  source        = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d808763ccac504eb7ddda7ceef2fc6a1ac"
+  source        = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d"
   name          = "${local.name}-arm64"
   desired_count = 3
   cluster       = data.aws_ecs_cluster.core_infra.cluster_name

--- a/examples/lb-service/main.tf
+++ b/examples/lb-service/main.tf
@@ -93,7 +93,7 @@ resource "aws_service_discovery_service" "this" {
 }
 
 module "ecs_service_definition" {
-  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service"
+  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d808763ccac504eb7ddda7ceef2fc6a1ac"
 
   name               = local.name
   desired_count      = 3

--- a/examples/lb-service/main.tf
+++ b/examples/lb-service/main.tf
@@ -93,7 +93,7 @@ resource "aws_service_discovery_service" "this" {
 }
 
 module "ecs_service_definition" {
-  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d808763ccac504eb7ddda7ceef2fc6a1ac"
+  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d"
 
   name               = local.name
   desired_count      = 3

--- a/examples/prometheus/main.tf
+++ b/examples/prometheus/main.tf
@@ -38,7 +38,7 @@ resource "aws_service_discovery_service" "this" {
 }
 
 module "ecs_service_definition" {
-  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d808763ccac504eb7ddda7ceef2fc6a1ac"
+  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d"
 
   name          = local.name
   desired_count = 1

--- a/examples/prometheus/main.tf
+++ b/examples/prometheus/main.tf
@@ -38,7 +38,7 @@ resource "aws_service_discovery_service" "this" {
 }
 
 module "ecs_service_definition" {
-  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service"
+  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d808763ccac504eb7ddda7ceef2fc6a1ac"
 
   name          = local.name
   desired_count = 1


### PR DESCRIPTION
## Description
- Pin ECS module to sha while module is undergoing changes

## Motivation and Context
- The current module source is pointed at a fork that is undergoing changes based on PR review feedback. This will pin the source to a stable version to avoid user disruption. Once the upstream PR is merged a separate PR will be opened to remove the fork source and instead use a versioned upstream source. The SHA used is from [March 13th](https://github.com/clowdhaus/terraform-aws-ecs/commits/master) prior to latest changes

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
