### PR TITLE
chore: Switch ECS module sources back to main project and off the forked copy; pin Aurora version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.1
+    rev: v1.77.2
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/examples/backend-service/main.tf
+++ b/examples/backend-service/main.tf
@@ -40,13 +40,14 @@ resource "aws_service_discovery_service" "this" {
 }
 
 module "ecs_service_definition" {
-  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d"
+  source  = "terraform-aws-modules/ecs/aws//modules/service"
+  version = "~> 5.0"
 
   deployment_controller = "ECS"
 
   name               = local.name
   desired_count      = 3
-  cluster            = data.aws_ecs_cluster.core_infra.cluster_name
+  cluster_arn        = data.aws_ecs_cluster.core_infra.arn
   enable_autoscaling = false
 
   subnet_ids = data.aws_subnets.private.ids

--- a/examples/backstage/main.tf
+++ b/examples/backstage/main.tf
@@ -22,7 +22,8 @@ locals {
 ################################################################################
 
 module "aurora_postgresdb" {
-  source = "terraform-aws-modules/rds-aurora/aws"
+  source  = "terraform-aws-modules/rds-aurora/aws"
+  version = "~> 8.0"
 
   name        = "backstage-db"
   engine      = "aurora-postgresql"
@@ -30,8 +31,12 @@ module "aurora_postgresdb" {
 
   vpc_id  = data.aws_vpc.vpc.id
   subnets = data.aws_subnets.private.ids
-
-  allowed_cidr_blocks = [for s in data.aws_subnet.private_cidr : s.cidr_block]
+  security_group_rules = {
+    private_subnets_ingress = {
+      description = "Allow ingress from VPC private subnets"
+      cidr_blocks = [for s in data.aws_subnet.private_cidr : s.cidr_block]
+    }
+  }
 
   storage_encrypted   = true
   apply_immediately   = true
@@ -42,10 +47,9 @@ module "aurora_postgresdb" {
     max_capacity = 2
   }
 
-  create_random_password = false
-  master_username        = "postgres"
-  master_password        = data.aws_secretsmanager_secret_version.postgresdb_master_password.secret_string
-  port                   = 5432
+  master_username = "postgres"
+  master_password = data.aws_secretsmanager_secret_version.postgresdb_master_password.secret_string
+  port            = 5432
 
   tags = local.tags
 }
@@ -141,11 +145,12 @@ resource "aws_service_discovery_service" "this" {
 }
 
 module "ecs_service_definition" {
-  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d"
+  source  = "terraform-aws-modules/ecs/aws//modules/service"
+  version = "~> 5.0"
 
   name          = local.name
   desired_count = 3
-  cluster       = data.aws_ecs_cluster.core_infra.cluster_name
+  cluster_arn   = data.aws_ecs_cluster.core_infra.arn
 
   subnet_ids = data.aws_subnets.private.ids
   security_group_rules = {
@@ -180,10 +185,16 @@ module "ecs_service_definition" {
   enable_execute_command = true
   create_iam_role        = false
   task_exec_iam_role_arn = one(data.aws_iam_roles.ecs_core_infra_exec_role.arns)
-  task_exec_secret_arns  = [data.aws_secretsmanager_secret.github_token.arn, data.aws_secretsmanager_secret.postgresdb_master_password.arn]
-  task_exec_ssm_param_arns = [aws_ssm_parameter.base_url.arn, aws_ssm_parameter.postgres_host.arn,
-  aws_ssm_parameter.postgres_port.arn, aws_ssm_parameter.postgres_user.arn]
-
+  task_exec_secret_arns = [
+    data.aws_secretsmanager_secret.github_token.arn,
+    data.aws_secretsmanager_secret.postgresdb_master_password.arn,
+  ]
+  task_exec_ssm_param_arns = [
+    aws_ssm_parameter.base_url.arn,
+    aws_ssm_parameter.postgres_host.arn,
+    aws_ssm_parameter.postgres_port.arn,
+    aws_ssm_parameter.postgres_user.arn,
+  ]
 
   container_definitions = {
     main_container = {

--- a/examples/core-infra/README.md
+++ b/examples/core-infra/README.md
@@ -63,7 +63,7 @@ terraform destroy
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ecs"></a> [ecs](#module\_ecs) | github.com/clowdhaus/terraform-aws-ecs | 73acc1d |
+| <a name="module_ecs"></a> [ecs](#module\_ecs) | terraform-aws-modules/ecs/aws | ~> 5.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
 
 ## Resources

--- a/examples/core-infra/main.tf
+++ b/examples/core-infra/main.tf
@@ -23,8 +23,8 @@ locals {
 ################################################################################
 
 module "ecs" {
-  source = "github.com/clowdhaus/terraform-aws-ecs?ref=73acc1d"
-  # version = "~> 4.0"
+  source  = "terraform-aws-modules/ecs/aws"
+  version = "~> 5.0"
 
   cluster_name = local.name
 

--- a/examples/graviton/main.tf
+++ b/examples/graviton/main.tf
@@ -180,11 +180,12 @@ resource "aws_service_discovery_service" "arm64" {
 }
 
 module "ecs_service_definition_amd64" {
-  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d"
+  source  = "terraform-aws-modules/ecs/aws//modules/service"
+  version = "~> 5.0"
 
   name          = local.name
   desired_count = 3
-  cluster       = data.aws_ecs_cluster.core_infra.cluster_name
+  cluster_arn   = data.aws_ecs_cluster.core_infra.arn
 
   subnet_ids = data.aws_subnets.private.ids
   security_group_rules = {
@@ -238,10 +239,12 @@ module "ecs_service_definition_amd64" {
 }
 
 module "ecs_service_definition_arm64" {
-  source        = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d"
+  source  = "terraform-aws-modules/ecs/aws//modules/service"
+  version = "~> 5.0"
+
   name          = "${local.name}-arm64"
   desired_count = 3
-  cluster       = data.aws_ecs_cluster.core_infra.cluster_name
+  cluster_arn   = data.aws_ecs_cluster.core_infra.arn
 
   subnet_ids = data.aws_subnets.private.ids
   security_group_rules = {

--- a/examples/lb-service/main.tf
+++ b/examples/lb-service/main.tf
@@ -93,11 +93,12 @@ resource "aws_service_discovery_service" "this" {
 }
 
 module "ecs_service_definition" {
-  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d"
+  source  = "terraform-aws-modules/ecs/aws//modules/service"
+  version = "~> 5.0"
 
   name               = local.name
   desired_count      = 3
-  cluster            = data.aws_ecs_cluster.core_infra.cluster_name
+  cluster_arn        = data.aws_ecs_cluster.core_infra.arn
   enable_autoscaling = false
 
   subnet_ids = data.aws_subnets.private.ids

--- a/examples/prometheus/main.tf
+++ b/examples/prometheus/main.tf
@@ -38,11 +38,12 @@ resource "aws_service_discovery_service" "this" {
 }
 
 module "ecs_service_definition" {
-  source = "github.com/clowdhaus/terraform-aws-ecs//modules/service?ref=73acc1d"
+  source  = "terraform-aws-modules/ecs/aws//modules/service"
+  version = "~> 5.0"
 
   name          = local.name
   desired_count = 1
-  cluster       = data.aws_ecs_cluster.core_infra.cluster_name
+  cluster_arn   = data.aws_ecs_cluster.core_infra.arn
 
   subnet_ids = data.aws_subnets.private.ids
   security_group_rules = {


### PR DESCRIPTION
## Description
- Now that https://github.com/terraform-aws-modules/terraform-aws-ecs/pull/76 is merged, the module source is switched back to the main project and off of the fork
- Add a loose version pin to the Aurora module; there was a [recent major change](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/pull/335) that removed the random password generation for the now preferred Aurora managed master password via SecretsManager and simplification of security group rules

## Motivation and Context
- Remove use of forked copy of modules and pin to avoid any surprises
- Closes #132 

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
