### PR TITLE
Updated the readme

### DIFF
--- a/terraform/fargate-examples/vpc-endpoints/README.md
+++ b/terraform/fargate-examples/vpc-endpoints/README.md
@@ -5,7 +5,7 @@
 This solution blueprint creates VPC Endpoints for S3, ECS, ECR(Private Repositories only), Secrets Manager, and Systems Manager, CloudWatch. There are two steps to deploying this blueprint:
 
 * Deploy the [core-infra](../core-infra/README.md). Note if you have already deployed the infra then you can reuse it as well.
-  * **NOTE:** If you would like to disable the NAT Gateway, change `enable_nat_gw = true` in `core-infra` [variables.tf](../core-infra/variables.tf). Please ensure that this solution blueprint deploys successfuly prior to disabling the NAT Gateway in `core-infra`.
+  * **NOTE:** If you would like to disable the NAT Gateway, change `enable_nat_gw = false` in `core-infra` [variables.tf](../core-infra/variables.tf). Please ensure that this solution blueprint deploys successfuly prior to disabling the NAT Gateway in `core-infra`.
 * Deploy the terraform templates in this repository using `terraform init` and `terraform apply`
 
 


### PR DESCRIPTION
## Description
I have updated the `vpc-endpoints` blueprint README.  I have corrected the documentation, which states to set the `enable_nat_gateway` to `true` value to disable the NAT Gateway, which is incorrect; the `enable_nat_gateway` must be set to `false` to disable the NAT gateway in the VPC module.

## Motivation and Context
This PR corrects the documentation of the `vpc-endpoints` blueprint.


## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
