### PR TITLE
Fix ecsdemo-cicd Dockerfile 

### DIFF
--- a/application-code/ecsdemo-cicd/Dockerfile
+++ b/application-code/ecsdemo-cicd/Dockerfile
@@ -1,11 +1,13 @@
 FROM public.ecr.aws/docker/library/alpine:latest
 
-RUN apk add --no-cache python3 && \
-python3 -m ensurepip && \
-pip3 install --upgrade pip
+RUN apk add --no-cache python3 py3-pip && \
+python3 -m venv /path/to/venv
+
+ENV PATH="/path/to/venv/bin:$PATH"
 
 WORKDIR /app
 ADD . /app
+
 RUN pip3 install -r requirements.txt
 
-CMD ["python", "app.py"]
+CMD ["python3", "app.py"]


### PR DESCRIPTION
## Description
Fixed ecsdemo-cicd Dockerfile for resolving the error. 

## Motivation and Context
With previous Dockerfile, the `ensurepip` process failed when setting up Python in Docker container. Based on error log suggestion, change codes for being managed using apk and installing additional packages in the virtual env. 

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
