### PR TITLE
fixes errors with building backstage in codebuild

### DIFF
--- a/terraform/fargate-examples/backstage/templates/buildspec.yml
+++ b/terraform/fargate-examples/backstage/templates/buildspec.yml
@@ -1,12 +1,17 @@
 version: 0.2
 
+env:
+  variables:
+    "DOCKER_BUILDKIT": "1"
+
 phases:
   install:
-    runtime_versions:
-      nodejs: 14
+    runtime-versions:
+      nodejs: 18
     commands:
       - npm install -g yarn
       - yarn install
+      - yarn tsc
   pre_build:
     commands:
       - echo $REPO_URL
@@ -21,7 +26,7 @@ phases:
       - echo "Building from $(pwd)"
       - echo Build started on `date`
       - echo Building the Docker image...
-      - yarn build
+      - yarn build:backend --config ../../app-config.yaml
       - yarn build-image
   post_build:
     commands:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I tried this example and it didn't work due to a number of CodeBuild errors.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- latest backstage requires newer version of node
- docker buildkit seems to be required
- `yarn build` was removed
- `runtime_versions` appears to have been a typo

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
