### PR TITLE
Rationalise bucket creation

### DIFF
--- a/terraform/fargate-examples/queue-processing/main.tf
+++ b/terraform/fargate-examples/queue-processing/main.tf
@@ -108,7 +108,7 @@ module "source_s3_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "~> 3.15"
 
-  bucket = "${local.name}-source-${local.region}-"
+  bucket_prefix = "${local.name}-src-${local.region}-"
 
   # For example only - please evaluate for your environment
   force_destroy = true
@@ -131,7 +131,7 @@ module "destination_s3_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "~> 3.15"
 
-  bucket_prefix = "${local.name}-destination-${local.region}-"
+  bucket_prefix = "${local.name}-dst-${local.region}-"
 
   # For example only - please evaluate for your environment
   force_destroy = true

--- a/terraform/fargate-examples/queue-processing/main.tf
+++ b/terraform/fargate-examples/queue-processing/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "us-west-2"
+  region = local.region
 }
 
 data "aws_caller_identity" "current" {}


### PR DESCRIPTION
## Description
Shorten S3 bucket names and ensure name uniqueness of the source one within the *queue-processing* example blueprint.

## Motivation and Context
The destination bucket name prefix was too long and the source bucket was created using the input `bucket` instead of `bucket_prefix`.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
