### PR TITLE
fix: disable read-only for the root filesystem of the queue-processing example

### DIFF
--- a/terraform/fargate-examples/queue-processing/main.tf
+++ b/terraform/fargate-examples/queue-processing/main.tf
@@ -36,7 +36,8 @@ module "ecs_service" {
 
   container_definitions = {
     (local.container_name) = {
-      image = module.ecr.repository_url
+      image                    = module.ecr.repository_url
+      readonly_root_filesystem = false
     }
   }
 


### PR DESCRIPTION
## Description
Disable read-only mode for the root filesystem of the *queue-processing* Fargate example.

## Motivation and Context
The *queue-processing* Fargate example cannot download files from S3 and store them locally as the root filesystem is mounted as read-only.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
