### PR TITLE
chore: add missing SQS endpoint

### DIFF
--- a/terraform/fargate-examples/vpc-endpoints/main.tf
+++ b/terraform/fargate-examples/vpc-endpoints/main.tf
@@ -42,7 +42,7 @@ module "vpc_endpoints" {
       }
     }
     },
-    { for service in toset(["ecr.api", "ecr.dkr", "ecs", "ecs-telemetry", "ecs-agent", "logs", "ssm", "secretsmanager"]) :
+    { for service in toset(["ecr.api", "ecr.dkr", "ecs", "ecs-telemetry", "ecs-agent", "sqs", "logs", "ssm", "secretsmanager"]) :
       replace(service, ".", "_") =>
       {
         service             = service


### PR DESCRIPTION
## Description
Add another endpoint for the SQS service.

## Motivation and Context
Without the SQS endpoint available, the *queue-processing* Fargate example cannot access the SQS job queue in absence of an Internet connection.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
