### PR TITLE
chore: restrict the actions of the Lambda role for the queue-processing example

### DIFF
--- a/terraform/fargate-examples/queue-processing/main.tf
+++ b/terraform/fargate-examples/queue-processing/main.tf
@@ -338,16 +338,9 @@ data "aws_iam_policy_document" "lambda_role" {
   }
 
   statement {
-    sid = "SQSReadWrite"
+    sid = "SQSReadAttributes"
     actions = [
-      "sqs:ChangeMessageVisibility",
-      "sqs:ChangeMessageVisibilityBatch",
-      "sqs:SendMessage",
-      "sqs:DeleteMessage",
-      "sqs:DeleteMessageBatch",
-      "sqs:GetQueueAttributes",
-      "sqs:GetQueueUrl",
-      "sqs:ReceiveMessage"
+      "sqs:GetQueueAttributes"
     ]
     resources = [module.sqs.queue_arn]
   }


### PR DESCRIPTION
## Description
Address this [open issue](https://github.com/aws-ia/ecs-blueprints/issues/206).

## Motivation and Context
See [open issue](https://github.com/aws-ia/ecs-blueprints/issues/206).

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
