### PR TITLE
chore: only use standalone tasks in the queue-processing example

### DIFF
--- a/terraform/fargate-examples/queue-processing/main.tf
+++ b/terraform/fargate-examples/queue-processing/main.tf
@@ -24,9 +24,11 @@ module "ecs_service" {
   source  = "terraform-aws-modules/ecs/aws//modules/service"
   version = "~> 5.6"
 
-  name          = local.name
-  desired_count = 3
-  cluster_arn   = data.aws_ecs_cluster.core_infra.arn
+  name        = local.name
+  cluster_arn = data.aws_ecs_cluster.core_infra.arn
+
+  # Use a Standalone Task Definition (w/o Service)
+  desired_count = 0
 
   # Task Definition
   enable_execute_command = true


### PR DESCRIPTION
## Description
Don't start any tasks under the ECS service as they are not necessary and fail continuously.

## Motivation and Context
The ECS task definition created within the `ecs_service` module is not usable as part of an ECS service for multiple reasons:
- it initially uses the `latest` tag to pull from ECR
- it does not set the environment variable used by the task, `S3_DEST_PREFIX`

The relevant [Lambda function](https://github.com/aws-ia/ecs-blueprints/blob/main/application-code/lambda-function-queue-trigger/lambda_function.py) correctly starts standalone tasks by setting the appropriate image tag and value of the above-mentioned environment variable.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
