### PR TITLE
chore: run Docker container as non-root user in the queue-processing example

### DIFF
--- a/application-code/container-queue-proc/Dockerfile
+++ b/application-code/container-queue-proc/Dockerfile
@@ -1,11 +1,17 @@
-FROM public.ecr.aws/docker/library/python:alpine3.16
+# See: https://gallery.ecr.aws/docker/library/python
+FROM public.ecr.aws/docker/library/python:3.9.19-alpine3.20
 
-RUN mkdir -p /tmp/ecsproc/
-
-WORKDIR /app
+RUN addgroup -S appgroup && \
+    adduser -S appuser -G appgroup
 
 COPY ./src /app
 
-RUN pip install -r requirements.txt
+WORKDIR /app
 
-ENTRYPOINT python app.py
+RUN pip install --no-cache-dir --prefer-binary -r requirements.txt
+
+USER appuser
+
+RUN mkdir -p /tmp/ecsproc
+
+ENTRYPOINT ["python", "app.py"]


### PR DESCRIPTION
## Description
Update base container and run Docker container as non-root user in the queue-processing example.

## Motivation and Context
Best practices.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
